### PR TITLE
chore: 取消不必要的Travis通知

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ notifications:
   webhooks:
     urls:
       - secure: "dDw0atTClUC7+Bnb3o52dcyRoTQ7xw/XURvcEAclv1aXY5zRe4H/hx0p8dSq0oFuvbHElhQLuINvcR1wBksJns6usdikKpHeEuEssPJAH0q9M3581VV6R/BoEpQRb69m2NwBs43dkWx9YE11DlT1e/0xmxMKDcEC8mRtzjIrr/WvQyGC0PziLHCPXURehpG/IFFouQUMYyhj+SC3lu5puG+g9NNFl+xG/0XAgylXjp37v8kE3W331AoBG3m77tntuz55FJsom+HulIKMFa5JyUBs4BICQbrEqzXM+DBMR+ofHDfT6aQuPOI4X/ee5Os7vwQ3UBZq9X6ddJm8sGZsBLBJvnQyrDU0Iompxkkllkxdl6rcSD6A/XWC0XNzxKkX0BUvfkPKBRcY9UPvg1AkYsRtcQLDCwcMNRQOCEAD4GDvqFShgNtNURKqLQ1ewl31vnC9VlJWiHGA1bSsPSbERNbYIjf8rvzZsdi4qzs9EFHSw8KVXGEtn4DV4ydfXPVcG9prEQu5cHHTLkTqUN0/RsRJbZvuLARo5Ni6HkvmNtCHJoMeIhoAaFUrprQAzhLVd0rt82+g7MXhJzkNfS4SWc3WcRWDSedXDi5zvwiAE61TBUzTMpKYHzbsE4toqDEgiiRPgZRkiQ0eIILVylwYdNM4pMy12n9aSdwrgqwkjFU="
-    on_success: always
+    on_success: change
     on_failure: always
-    on_start: never
+    on_start: change
     on_cancel: always
     on_error: always


### PR DESCRIPTION
应用此commit的更改后，Travis只在build失败时，以及build状态从失败转变为成功时发送通知，可以减少信息噪声。